### PR TITLE
Purging will try a little harder.

### DIFF
--- a/src/em.erl
+++ b/src/em.erl
@@ -527,6 +527,7 @@ invoke(M, Mod, Fun, Args) ->
 %%------------------------------------------------------------------------------
 unload_mock_modules(#state{mocked_modules = MMs}) ->
     [begin
+   code:purge(Mod),
 	 code:delete(Mod),
 	 code:purge(Mod),
          case MaybeBin of
@@ -568,6 +569,7 @@ install_mock_module(Mod, Expectations) ->
         compile:forms([erl_syntax:revert(F)
                        || F <- ModHeaderSyn ++ FunFormsSyn]),
 
+    code:purge(Mod),
     code:delete(Mod),
     code:purge(Mod),
     {module, _} = load_module(Mod, Code),


### PR DESCRIPTION
Hi, there were some issues with the maven-erlang-plugin and running 2 test-phases after one another, using the same testing backend node. We found out that the purging in erlymock didn't take hard enough, and this simple change seems to do the trick.

After purging harder, the mocked modules are no longer locked and consecutive test-executions on the same backend node seem to work much better.

Please pull and release! Yay!
