### PR TITLE
Removed the require_otp_vsn from rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,2 @@
-{require_otp_vsn, "R13B04|R14"}.
 {cover_enabled, true}.
 {erl_opts, [debug_info, fail_on_warning]}.


### PR DESCRIPTION
Hello,

I've removed the require_otp_vsn directive from rebar.config to make it possible to use ErlyMock under Erlang/OTP versions newer than R14 too.

Regards
/Björn Bylander
