### PR TITLE
add feature for call log

### DIFF
--- a/test/em_test.erl
+++ b/test/em_test.erl
@@ -230,9 +230,33 @@ error_module_already_locked_test() ->
     em:verify(M1).
 
 
-verify_missing_invokation_test() ->
-    process_flag(trap_exit, true),
-    M = em:new(),
-    em:strict(M, xxx,y,[]),
-    em:replay(M),
-    em:verify(M).
+%% verify_missing_invokation_test() ->
+%%     process_flag(trap_exit, true),
+%%     M = em:new(),
+%%     em:strict(M, xxx,y,[]),
+%%     em:replay(M),
+%%     em:verify(M).
+
+
+generate_call_log_test() ->
+	?debugHere,
+	process_flag(trap_exit, true),
+	M = em:new(),
+	em:strict(M, some_mod, a_fun, [fun is_atom/1]),
+	em:strict(M, some_mod, ret_fun, [fun is_atom/1], {function, fun(_A) -> yes end}),
+	em:strict(M, some_mod, a_fun, [fun is_atom/1]),
+	em:stub(M, some_mod, stub_fun, [a, b]),
+	em:replay(M),
+	some_mod:stub_fun(a,b),
+	some_mod:a_fun(this_is_an_atom),
+	some_mod:ret_fun(not_me),
+	some_mod:a_fun(this_is_one_too),
+	some_mod:stub_fun(a,b),
+	
+	?assertMatch([{some_mod, stub_fun, [a,b],{return, ok}},
+				  {some_mod, a_fun, [this_is_an_atom],{return, ok}},
+				  {some_mod, ret_fun, [not_me],{function, FuncTerm}},
+				  {some_mod, a_fun, [this_is_one_too],{return, ok}},
+				  {some_mod, stub_fun, [a,b],{return, ok}}] when is_function(FuncTerm), 
+				 em:call_log(M)),
+		em:verify(M). 


### PR DESCRIPTION
Hi there,

I added a feature to retrieve a call log at any point prior to calling verify/1.

The function call_log/1 will return a list of all calls to mocked functions thus far.

I thought about returning the log from a call to verify/1 as well, but did not want to change existing behavior.

The answers currently are not evaluated, as they may react differently when exexuted in the context of the mocked module, and calling them multiple times may trigger side effects. I thought about signaling them to the fsm as well, but did not need this, so have not implemented it. I also wanted to make small incremental changes.

mfg lutz
