### PR TITLE
Remove calls to erlang:get_stacktrace/0

### DIFF
--- a/src/em.erl
+++ b/src/em.erl
@@ -760,13 +760,13 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 -spec invoke(M :: term(), Mod :: term(), Fun :: fun(), Args :: list()) ->
                     {Value :: term()}.
 invoke(M, Mod, Fun, Args) ->
-    Trace = erlang:get_stacktrace(),
-    try io:format("~nEM: ~w:~w ~p",[Mod,Fun, Args]) catch _:_ -> ok end,
+    {current_stacktrace, Trace} = erlang:process_info(self(), current_stacktrace),
+    try io:format("~nEM: ~w:~w ~p", [Mod, Fun, Args]) catch _:_ -> ok end,
     Rv = case gen_statem:call(M, {invokation, Mod, Fun, Args, self()}, infinity) of
              {return, Value} ->
                  Value;
              {'$em_error' , WTF} ->
-                 (catch io:format(" *ERROR* ->  ~p~nAT: ~p~n~n",[WTF, Trace])),
+                 (catch io:format(" *ERROR* ->  ~p~nAT: ~p~n~n", [WTF, Trace])),
                  exit({mock_error, WTF});
              {function, F} ->
                  F(Args)


### PR DESCRIPTION
erlang:get_stacktrace/0 is deprecated and removed starting with OTP-24. Thus, it is necessary to remove invocations to this function.

There's only one reasonable replacement if one wants to catch the call stack of a process: querying the current stacktrace via process_info/2. Although the return values are not equivalent, it should work sufficiently in this context.